### PR TITLE
Gemiddelde calculeren gefixt

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,7 +68,7 @@ export default {
   },
   computed: {
     average: function computeAverage() {
-      return Math.round (this.cijfers.reduce((sum, e) => sum + e.nummer, 0) / this.cijfers.filter(el => el.nummer != null || el.nummer != isNaN).length * 10) / 10;
+      return Math.round (this.cijfers.reduce((sum, e) => sum + e.nummer, 0) / this.cijfers.filter(el => el.nummer != null).length * 10) / 10;
     },
   }
 }


### PR DESCRIPTION
**NL:** Ik heb het calculeren van het gemiddelde gefixt, eerst zou hij door de totale hoeveelheid cijfers delen, i.p.v. alleen de cijfers die cijfers hebben en niet null zijn.

**EN:** I have fixed the calculating of the average grade, at first it would divide the grades by the total amount of grades, instead of only the grades that actually had grades and weren't null.